### PR TITLE
Added setup.sh. Modified README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,43 @@ Summary of the results available at https://github.com/manutamminen/epicpcr_6/bl
 - VSEARCH
 - SINA
 - FastTree
-- Tidyverse
+- Tidyverse and Ape (R Packages)
 
 Download the raw data into data/raw.
 
 Start the processing pipeline by invoking `snakemake --cores all report`.
 
 
+## Building using Singularity Container
+
+1. Install Singularity using the official guide at [sylabs.io](https://sylabs.io/guides/3.8/admin-guide/installation.html)
+2. Clone this repository to get the snakemake file (containing all the commands) and all the other scripts
+
+```
+git clone https://github.com/manutamminen/epicpcr_6.git
+```
+
+3. Move into folder
+
+```
+cd epicpcr_6
+```
+
+4. Make the setup script an executable and run it. This script downloads the raw data and the container to the appropriate sub-folders.
+
+```
+chmod +x setup.sh
+./setup.sh
+```
+
+5. Run the snakemake pipeline
+
+```
+singularity run container.sif snakemake --cores all report
+```
+
+### Extras
+
+1. If you would like to shell into the singularity container and then run commands from inside it, you can use the following command: `singularity shell container.sif`
+
+2. If you are working on windows using a vagrant virtual machine to run singularity, you might run into an insufficient memory problem (`Fatal error: Unable to allocate enough memory`) at some point. In this case, use instructions [here](https://ostechnix.com/how-to-increase-memory-and-cpu-on-vagrant-machine/) to increase memory allocated to the vagrant machine.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Download and prepare raw data
+mkdir data
+cd data
+wget https://zenodo.org/record/5101839/files/epic6.tar.gz
+tar -xvf epic6.tar.gz
+rm epic6.tar.gz
+mv epic6 raw
+cd ..
+
+# Archive the old final output file
+cd docs
+mv index.md index.md.archive
+cd ..
+
+# Download the singularity container
+singularity pull library://jeevannavar/default/epicpcr-singularity-container:ver1
+mv epicpcr-singularity-container_ver1.sif container.sif


### PR DESCRIPTION
Added setup script which downloads raw data and container into appropriate sub-folders. It also archives the file docs/index.md. If it stays as is, snakemake does not perform any steps because the final output is already present.
Added instructions to use container in README.